### PR TITLE
Create a :darwin alias for :osx

### DIFF
--- a/os/BUILD
+++ b/os/BUILD
@@ -72,6 +72,12 @@ alias(
     actual = ":osx",
 )
 
+# MacOS knows itself (eg in `uname`) as Darwin, not as osx or macos.
+alias(
+    name = "darwin",
+    actual = ":osx",
+)
+
 constraint_value(
     name = "tvos",
     constraint_setting = ":os",


### PR DESCRIPTION
MacOS knows itself as Darwin, as do some ABIs.

```shell
$ arch; uname -a
arm64
Darwin PG9JK00XLN.local 22.2.0 Darwin Kernel Version 22.2.0: Fri Nov 11 02:03:51 PST 2022; root:xnu-8792.61.2~4/RELEASE_ARM64_T6000 arm64
```

Python for instances uses ABI tags like `cpython-38m-darwin`. It's convenient to be able to refer to the same constraint consistently. This change consists only of the appropriate alias.